### PR TITLE
Add itinerary processing engine and API

### DIFF
--- a/yg_tour_builder/backend/engine/calculator.py
+++ b/yg_tour_builder/backend/engine/calculator.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Dict, Any, List
+
+from .rules import SERVICE_PRICES
+
+
+def calculate_costs(days: Dict[int, Dict[str, Any]]) -> Dict[str, Any]:
+    """Calculate price estimates for the parsed itinerary."""
+    total = 0.0
+    detail: List[Dict[str, Any]] = []
+    for day, info in sorted(days.items()):
+        for service in info.get("services", []):
+            key = service.lower()
+            price = SERVICE_PRICES.get(key, 0.0)
+            total += price
+            detail.append({"day": day, "service": service, "price": price})
+    return {"total": total, "detail": detail}

--- a/yg_tour_builder/backend/engine/generator.py
+++ b/yg_tour_builder/backend/engine/generator.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Dict, Any, List
+from pathlib import Path
+from io import BytesIO
+
+from docx import Document
+import pandas as pd
+
+
+def create_word(days: Dict[int, Dict[str, Any]]) -> bytes:
+    """Generate a Word document representing the itinerary."""
+    doc = Document()
+    for day in sorted(days):
+        info = days[day]
+        doc.add_heading(f"Day {day}", level=1)
+        if info.get("description"):
+            doc.add_paragraph(info["description"])
+        for service in info.get("services", []):
+            doc.add_paragraph(service, style="List Bullet")
+    buffer = BytesIO()
+    doc.save(buffer)
+    return buffer.getvalue()
+
+
+def create_excel(detail: List[Dict[str, Any]]) -> bytes:
+    """Generate an Excel file with pricing details."""
+    df = pd.DataFrame(detail)
+    buffer = BytesIO()
+    df.to_excel(buffer, index=False)
+    return buffer.getvalue()

--- a/yg_tour_builder/backend/engine/parser.py
+++ b/yg_tour_builder/backend/engine/parser.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Dict, List, Any
+import re
+
+from docx import Document
+
+
+def parse_word(path: str) -> Dict[int, Dict[str, Any]]:
+    """Parse a Word document and extract itinerary data.
+
+    The parser expects sections starting with "Day N" or "День N" headings.
+    Everything until the next heading is treated as that day's description
+    with bullet list paragraphs interpreted as services.
+    """
+    doc = Document(path)
+    days: Dict[int, Dict[str, Any]] = {}
+    current_day: int | None = None
+    for para in doc.paragraphs:
+        text = para.text.strip()
+        if not text:
+            continue
+        match = re.match(r"(?:Day|День)\s*(\d+)", text, re.IGNORECASE)
+        if match:
+            current_day = int(match.group(1))
+            days[current_day] = {"description": "", "services": []}
+            continue
+        if current_day is None:
+            continue
+        if para.style.name.lower().startswith("list") or text.startswith("-") or text.startswith("•"):
+            days[current_day]["services"].append(text.lstrip("-• "))
+        else:
+            if days[current_day]["description"]:
+                days[current_day]["description"] += " " + text
+            else:
+                days[current_day]["description"] = text
+    return days

--- a/yg_tour_builder/backend/engine/rules.py
+++ b/yg_tour_builder/backend/engine/rules.py
@@ -1,0 +1,9 @@
+"""Pricing rules for services used in itineraries."""
+
+# Map service keywords to their unit prices
+SERVICE_PRICES = {
+    "hotel": 100.0,
+    "excursion": 50.0,
+    "transfer": 30.0,
+    "meal": 20.0,
+}


### PR DESCRIPTION
## Summary
- implement Word itinerary parser
- compute pricing estimates from parsed services
- generate Word & Excel documents
- expose API endpoints for uploading itineraries and downloading documents

## Testing
- `python3 -m py_compile yg_tour_builder/backend/engine/*.py yg_tour_builder/backend/api/routes.py yg_tour_builder/backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68401912ffb08330b432d52783343f8b