### PR TITLE
Add Excel and Word download features

### DIFF
--- a/yg_tour_builder/backend/api/routes.py
+++ b/yg_tour_builder/backend/api/routes.py
@@ -53,6 +53,7 @@ async def download_word(request: Request):
 
 @router.post("/download/excel")
 async def download_excel(request: Request):
-    detail = await request.json()
-    content = generator.create_excel(detail)
+    days = await request.json()
+    estimate = calculator.calculate_costs(days)
+    content = generator.create_excel(estimate["detail"])
     return StreamingResponse(iter([content]), media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", headers={"Content-Disposition": "attachment; filename=estimate.xlsx"})

--- a/yg_tour_builder/frontend/src/TourEditor.jsx
+++ b/yg_tour_builder/frontend/src/TourEditor.jsx
@@ -68,7 +68,7 @@ export default function TourEditor() {
     }
 
     try {
-      const res = await fetch("http://localhost:8000/estimate", {
+      const res = await fetch("/estimate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -93,7 +93,7 @@ export default function TourEditor() {
     });
 
     try {
-      const res = await fetch("http://localhost:8000/generate/markdown", {
+      const res = await fetch("/generate/markdown", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -119,7 +119,7 @@ export default function TourEditor() {
       };
     });
     try {
-      const res = await fetch("http://localhost:8000/download/word", {
+      const res = await fetch("/download/word", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -141,15 +141,24 @@ export default function TourEditor() {
   };
 
   const handleDownloadExcel = async () => {
+    const payload = {};
+    days.forEach((day, i) => {
+      const dayNum = i + 1;
+      const filtered = day.services.filter((s) => s.trim());
+      payload[dayNum] = {
+        description: day.description.trim(),
+        services: filtered,
+      };
+    });
     try {
-      const res = await fetch("http://localhost:8000/download/excel", {
+      const res = await fetch("/download/excel", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Accept:
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         },
-        body: JSON.stringify(detail),
+        body: JSON.stringify(payload),
       });
       const blob = await res.blob();
       const url = window.URL.createObjectURL(blob);

--- a/yg_tour_builder/frontend/src/TourEditor.jsx
+++ b/yg_tour_builder/frontend/src/TourEditor.jsx
@@ -108,6 +108,61 @@ export default function TourEditor() {
     }
   };
 
+  const handleDownloadWord = async () => {
+    const payload = {};
+    days.forEach((day, i) => {
+      const dayNum = i + 1;
+      const filtered = day.services.filter((s) => s.trim());
+      payload[dayNum] = {
+        description: day.description.trim(),
+        services: filtered,
+      };
+    });
+    try {
+      const res = await fetch("http://localhost:8000/download/word", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        },
+        body: JSON.stringify(payload),
+      });
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "itinerary.docx";
+      link.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("Ошибка скачивания Word:", err);
+    }
+  };
+
+  const handleDownloadExcel = async () => {
+    try {
+      const res = await fetch("http://localhost:8000/download/excel", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept:
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        },
+        body: JSON.stringify(detail),
+      });
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "estimate.xlsx";
+      link.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("Ошибка скачивания Excel:", err);
+    }
+  };
+
   useEffect(() => {
     fetchEstimate();
   }, [days, numPeople, season]);
@@ -206,6 +261,18 @@ export default function TourEditor() {
           onClick={handleGenerate}
         >
           📥 Сгенерировать Markdown и смету
+        </button>
+        <button
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          onClick={handleDownloadExcel}
+        >
+          💾 Скачать смету (Excel)
+        </button>
+        <button
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          onClick={handleDownloadWord}
+        >
+          💾 Скачать маршрут (Word)
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- enable downloading itinerary as Word doc and estimate as Excel file
- include buttons in editor UI to trigger downloads

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68405b425bbc8330a7ccd2331d7c2a76