### PR TITLE
Add backend tests and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -20,4 +20,3 @@ Install Node.js dependencies and launch the development server.
 cd yg_tour_builder/frontend
 npm install
 npm run dev
-сodex/remove-terminal-prompts-and-clean-files

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ typing-inspection==0.4.1
 typing_extensions==4.14.0
 tzdata==2025.2
 uvicorn==0.34.3
+python-multipart==0.0.9
+openpyxl==3.1.5

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+# Add backend directory to path for importing main app
+BACKEND_DIR = os.path.join(os.path.dirname(__file__), '..', 'yg_tour_builder', 'backend')
+sys.path.append(os.path.abspath(BACKEND_DIR))
+
+from main import app
+
+@pytest.mark.asyncio
+async def test_generate_markdown():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        payload = {"1": {"description": "Test day", "services": ["hotel"]}}
+        resp = await ac.post("/generate/markdown", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["markdown"].startswith("##")
+
+@pytest.mark.asyncio
+async def test_estimate():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        payload = {"1": {"services": ["hotel", "meal"]}}
+        resp = await ac.post("/estimate", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 120.0
+    assert len(data["detail"]) == 2
+
+@pytest.mark.asyncio
+async def test_download_excel_and_word():
+    payload = {"1": {"services": ["hotel"]}}
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        res_xlsx = await ac.post("/download/excel", json=payload)
+        res_docx = await ac.post("/download/word", json=payload)
+    assert res_xlsx.status_code == 200
+    assert res_docx.status_code == 200
+    assert res_xlsx.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    assert res_docx.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document")


### PR DESCRIPTION
## Summary
- fix README instructions
- add MIT license
- test FastAPI routes for markdown generation and document downloads
- include `python-multipart` and `openpyxl` test deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405640dec483309855339bc707561c